### PR TITLE
Add .gitignore and .rustfmt.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target/

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
Here's a quick fix to make working with the mp3-metadata project a little easier.

The `.rustfmt.toml` configuration _disables_ auto-formatting via `rustfmt`, which is helpful for those of us who have our development machines set up to automatically reformat Rust source files whenever we save the file in our editor. Otherwise, we get a lot of unrelated changes (e.g., whitespace changes) in the source files.

For everyone else who is not using `rustfmt`, they'll see no change.