### PR TITLE
always read to the end of id3 tag

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -65,8 +65,9 @@ fn get_id3(i: &mut u32, buf: &[u8], meta: &mut MP3Metadata) -> Result<(), Error>
             }
             x += header_size as usize - 4;
         }
+
+        *i = x as u32 + tag_size as u32;
         if x + tag_size >= buf.len() {
-            *i = x as u32 + tag_size as u32;
             return Ok(())
         }
 


### PR DESCRIPTION
When unsync is not active (I had a few files where this was the case) in an ID3-tag, there may occur byte sequences that look like a non-mp3 sync marker.

This change makes it that reading an ID3 tag will move the current reading position to after the tag, so nothing that looks like a sync in the tag will be falsely recognized as mpeg frame.