### PR TITLE
buffer cursor was not advanced by the header size when no extended header

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -50,8 +50,9 @@ fn get_id3(i: &mut u32, buf: &[u8], meta: &mut MP3Metadata) -> Result<(), Error>
         let use_sync = buf[x + 5] & 0x80 != 0;
         let has_extended_header = buf[x + 5] & 0x40 != 0;
 
+        x += 10;
+
         if has_extended_header {
-            x += 10;
             if x + 4 >= buf.len() {
                 *i = x as u32;
                 return Ok(())


### PR DESCRIPTION
The buffer cursor was advanced by the header size only in presence of an extended header. Therefore only ID3v2 tags with extended header was decoded.