### PR TITLE
channeltype location fix

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -310,7 +310,7 @@ fn read_header(buf: &[u8], i: &mut u32, meta: &mut MP3Metadata) -> Result<bool, 
         frame.private_bit = (header >> 8) & 1 == 1;
 
         frame.chan_type = ChannelType::from((header >> 6) & 3);
-        let (intensity, ms_stereo) = match (header >> 2) & 3 {
+        let (intensity, ms_stereo) = match (header >> 4) & 3 {
             0x1 => (true, false),
             0x2 => (false, true),
             0x3 => (true, true),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -309,7 +309,7 @@ fn read_header(buf: &[u8], i: &mut u32, meta: &mut MP3Metadata) -> Result<bool, 
         frame.padding = (header >> 9) & 1 == 1;
         frame.private_bit = (header >> 8) & 1 == 1;
 
-        frame.chan_type = ChannelType::from((header >> 4) & 3);
+        frame.chan_type = ChannelType::from((header >> 6) & 3);
         let (intensity, ms_stereo) = match (header >> 2) & 3 {
             0x1 => (true, false),
             0x2 => (false, true),

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -50,7 +50,7 @@ fn basic() {
         assert_eq!(frame.sampling_freq, 44100, "sampling freq");
         assert_eq!(frame.padding, false, "padding");
         assert_eq!(frame.private_bit, false, "private bit");
-        assert_eq!(frame.chan_type, mp3_metadata::ChannelType::Stereo, "channel type");
+        assert_eq!(frame.chan_type, mp3_metadata::ChannelType::SingleChannel, "channel type");
         assert_eq!(frame.intensity_stereo, false, "intensity stereo");
         assert_eq!(frame.ms_stereo, false, "ms stereo");
         assert_eq!(frame.copyright, mp3_metadata::Copyright::None, "copyright");

--- a/tests/truncate.rs
+++ b/tests/truncate.rs
@@ -14,7 +14,7 @@ fn truncate() {
         assert_eq!(frame.sampling_freq, 44100);
         assert_eq!(frame.padding, false);
         assert_eq!(frame.private_bit, false);
-        assert_eq!(frame.chan_type, mp3_metadata::ChannelType::Stereo);
+        assert_eq!(frame.chan_type, mp3_metadata::ChannelType::SingleChannel);
         assert_eq!(frame.intensity_stereo, false);
         assert_eq!(frame.ms_stereo, false);
         assert_eq!(frame.copyright, mp3_metadata::Copyright::None);


### PR DESCRIPTION
It looks like the channel type and mode extension location is off by 2 (4 instead of 6). Code and tests updated to reflect assets/test.mp3:

```
11111111 11111010 10010000 11000000
                           ^^
```

Mode bytes are 11 (mono) and mode extension bytes are 00 in the test file.
