### PR TITLE
Adding frame offset

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -325,6 +325,7 @@ fn read_header(buf: &[u8], i: &mut u32, meta: &mut MP3Metadata) -> Result<bool, 
                                           frame.layer,
                                           frame.sampling_freq);
         frame.position = meta.duration;
+        frame.offset = *i;
 
         if let Some(dur) = frame.duration {
             meta.duration += dur;

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,7 @@ pub struct Frame {
     pub emphasis: Emphasis,
     pub duration: Option<Duration>,
     pub position: Duration,
+    pub offset: u32,
 }
 
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
Knowing frame offset from start can be useful to know from which position in file/buffer the frame can be read (taking ID3 tag into account) 