### PR TITLE
feat: Clean up lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mp3-metadata"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "Metadata parser for MP3 files"
@@ -13,5 +13,5 @@ keywords = ["mp3", "metadata"]
 name = "mp3_metadata"
 
 [dev-dependencies]
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.12.4", features = ["blocking"] }
 simplemad = "0.9"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -14,11 +14,11 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let err = match *self {
-            Error::FileError => "An I/O error occurred",
-            Error::NotMP3 => "The file is not a valid MP3 file",
-            Error::NoHeader => "The file is missing an MP3 header",
-            Error::DuplicatedIDV3 => "The MP3 file contains a duplicate IDv3 frame",
-            Error::InvalidData => "The MP3 metadata is invalid",
+            Self::FileError => "An I/O error occurred",
+            Self::NotMP3 => "The file is not a valid MP3 file",
+            Self::NoHeader => "The file is missing an MP3 header",
+            Self::DuplicatedIDV3 => "The MP3 file contains a duplicate IDv3 frame",
+            Self::InvalidData => "The MP3 metadata is invalid",
         };
         err.fmt(f)
     }
@@ -35,18 +35,18 @@ pub enum Version {
 }
 
 impl Default for Version {
-    fn default() -> Version {
-        Version::Unknown
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
 impl From<u32> for Version {
-    fn from(c: u32) -> Version {
+    fn from(c: u32) -> Self {
         match c {
-            0x00 => Version::MPEG2_5,
-            0x01 => Version::Reserved,
-            0x02 => Version::MPEG2,
-            0x03 => Version::MPEG1,
+            0x00 => Self::MPEG2_5,
+            0x01 => Self::Reserved,
+            0x02 => Self::MPEG2,
+            0x03 => Self::MPEG1,
             _ => unreachable!(),
         }
     }
@@ -62,18 +62,18 @@ pub enum Layer {
 }
 
 impl Default for Layer {
-    fn default() -> Layer {
-        Layer::Unknown
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
 impl From<u32> for Layer {
-    fn from(c: u32) -> Layer {
+    fn from(c: u32) -> Self {
         match c {
-            0x0 => Layer::Reserved,
-            0x1 => Layer::Layer3,
-            0x2 => Layer::Layer2,
-            0x3 => Layer::Layer1,
+            0x0 => Self::Reserved,
+            0x1 => Self::Layer3,
+            0x2 => Self::Layer2,
+            0x3 => Self::Layer1,
             _ => unreachable!(),
         }
     }
@@ -88,16 +88,16 @@ pub enum CRC {
 }
 
 impl Default for CRC {
-    fn default() -> CRC {
-        CRC::NotAdded
+    fn default() -> Self {
+        Self::NotAdded
     }
 }
 
 impl From<u32> for CRC {
-    fn from(c: u32) -> CRC {
+    fn from(c: u32) -> Self {
         match c {
-            0x00 => CRC::Added,
-            0x01 => CRC::NotAdded,
+            0x00 => Self::Added,
+            0x01 => Self::NotAdded,
             _ => unreachable!(),
         }
     }
@@ -113,18 +113,18 @@ pub enum ChannelType {
 }
 
 impl Default for ChannelType {
-    fn default() -> ChannelType {
-        ChannelType::Unknown
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
 impl From<u32> for ChannelType {
-    fn from(c: u32) -> ChannelType {
+    fn from(c: u32) -> Self {
         match c {
-            0x0 => ChannelType::Stereo,
-            0x1 => ChannelType::JointStereo,
-            0x2 => ChannelType::DualChannel,
-            0x3 => ChannelType::SingleChannel,
+            0x0 => Self::Stereo,
+            0x1 => Self::JointStereo,
+            0x2 => Self::DualChannel,
+            0x3 => Self::SingleChannel,
             _ => unreachable!(),
         }
     }
@@ -137,16 +137,16 @@ pub enum Copyright {
 }
 
 impl Default for Copyright {
-    fn default() -> Copyright {
-        Copyright::Some
+    fn default() -> Self {
+        Self::Some
     }
 }
 
 impl From<u32> for Copyright {
-    fn from(c: u32) -> Copyright {
+    fn from(c: u32) -> Self {
         match c {
-            0x0 => Copyright::None,
-            0x1 => Copyright::Some,
+            0x0 => Self::None,
+            0x1 => Self::Some,
             _ => unreachable!(),
         }
     }
@@ -160,16 +160,16 @@ pub enum Status {
 }
 
 impl Default for Status {
-    fn default() -> Status {
-        Status::Unknown
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
 impl From<u32> for Status {
-    fn from(c: u32) -> Status {
+    fn from(c: u32) -> Self {
         match c {
-            0x0 => Status::Copy,
-            0x1 => Status::Original,
+            0x0 => Self::Copy,
+            0x1 => Self::Original,
             _ => unreachable!(),
         }
     }
@@ -189,18 +189,18 @@ pub enum Emphasis {
 }
 
 impl Default for Emphasis {
-    fn default() -> Emphasis {
-        Emphasis::Unknown
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
 impl From<u32> for Emphasis {
-    fn from(c: u32) -> Emphasis {
+    fn from(c: u32) -> Self {
         match c {
-            0x0 => Emphasis::None,
-            0x1 => Emphasis::MicroSeconds,
-            0x2 => Emphasis::Reserved,
-            0x3 => Emphasis::CCITT,
+            0x0 => Self::None,
+            0x1 => Self::MicroSeconds,
+            0x2 => Self::Reserved,
+            0x3 => Self::CCITT,
             _ => unreachable!(),
         }
     }
@@ -340,150 +340,148 @@ pub enum Genre {
 }
 
 impl Default for Genre {
-    fn default() -> Genre {
-        Genre::Unknown
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
 impl<'a> From<&'a str> for Genre {
-    fn from(c: &'a str) -> Genre {
-        match c.parse::<u8>() {
-            Ok(nb) => Genre::from(nb),
-            Err(_) => Genre::Something(c.to_owned()),
-        }
+    fn from(c: &'a str) -> Self {
+        c.parse::<u8>().map_or_else(|_| Self::Something(c.to_owned()), Self::from)
     }
 }
 
 impl From<u8> for Genre {
-    fn from(c: u8) -> Genre {
+    #[allow(clippy::too_many_lines)]
+    fn from(c: u8) -> Self {
         match c {
-            0 => Genre::Blues,
-            1 => Genre::ClassicRock,
-            2 => Genre::Country,
-            3 => Genre::Dance,
-            4 => Genre::Disco,
-            5 => Genre::Funk,
-            6 => Genre::Grunge,
-            7 => Genre::HipHop,
-            8 => Genre::Jazz,
-            9 => Genre::Metal,
-            10 => Genre::NewAge,
-            11 => Genre::Oldies,
-            12 => Genre::Other,
-            13 => Genre::Pop,
-            14 => Genre::RAndB,
-            15 => Genre::Rap,
-            16 => Genre::Reggae,
-            17 => Genre::Rock,
-            18 => Genre::Techno,
-            19 => Genre::Industrial,
-            20 => Genre::Alternative,
-            21 => Genre::Ska,
-            22 => Genre::DeathMetal,
-            23 => Genre::Pranks,
-            24 => Genre::Soundtrack,
-            25 => Genre::EuroTechno,
-            26 => Genre::Ambient,
-            27 => Genre::TripHop,
-            28 => Genre::Vocal,
-            29 => Genre::JazzFunk,
-            30 => Genre::Fusion,
-            31 => Genre::Trance,
-            32 => Genre::Classical,
-            33 => Genre::Instrumental,
-            34 => Genre::Acid,
-            35 => Genre::House,
-            36 => Genre::Game,
-            37 => Genre::SoundClip,
-            38 => Genre::Gospel,
-            39 => Genre::Noise,
-            40 => Genre::AlternRock,
-            41 => Genre::Bass,
-            42 => Genre::Soul,
-            43 => Genre::Punk,
-            44 => Genre::Space,
-            45 => Genre::Meditative,
-            46 => Genre::InstrumentalPop,
-            47 => Genre::InstrumentalRock,
-            48 => Genre::Ethnic,
-            49 => Genre::Gothic,
-            50 => Genre::Darkwave,
-            51 => Genre::TechnoIndustrial,
-            52 => Genre::Electronic,
-            53 => Genre::PopFolk,
-            54 => Genre::Eurodance,
-            55 => Genre::Dream,
-            56 => Genre::SouthernRock,
-            57 => Genre::Comedy,
-            58 => Genre::Cult,
-            59 => Genre::Gangsta,
-            60 => Genre::Top40,
-            61 => Genre::ChristianRap,
-            62 => Genre::PopFunk,
-            63 => Genre::Jungle,
-            64 => Genre::NativeAmerican,
-            65 => Genre::Cabaret,
-            66 => Genre::NewWave,
-            67 => Genre::Psychadelic,
-            68 => Genre::Rave,
-            69 => Genre::Showtunes,
-            70 => Genre::Trailer,
-            71 => Genre::LoFi,
-            72 => Genre::Tribal,
-            73 => Genre::AcidPunk,
-            74 => Genre::AcidJazz,
-            75 => Genre::Polka,
-            76 => Genre::Retro,
-            77 => Genre::Musical,
-            78 => Genre::RockAndRoll,
-            79 => Genre::HardRock,
-            80 => Genre::Folk,
-            81 => Genre::FolkRock,
-            82 => Genre::NationalFolk,
-            83 => Genre::Swing,
-            84 => Genre::FastFusion,
-            85 => Genre::Bebob,
-            86 => Genre::Latin,
-            87 => Genre::Revival,
-            88 => Genre::Celtic,
-            89 => Genre::Bluegrass,
-            90 => Genre::Avantgarde,
-            91 => Genre::GothicRock,
-            92 => Genre::ProgressiveRock,
-            93 => Genre::PsychedelicRock,
-            94 => Genre::SymphonicRock,
-            95 => Genre::SlowRock,
-            96 => Genre::BigBand,
-            97 => Genre::Chorus,
-            98 => Genre::EasyListening,
-            99 => Genre::Acoustic,
-            100 => Genre::Humour,
-            101 => Genre::Speech,
-            102 => Genre::Chanson,
-            103 => Genre::Opera,
-            104 => Genre::ChamberMusic,
-            105 => Genre::Sonata,
-            106 => Genre::Symphony,
-            107 => Genre::BootyBrass,
-            108 => Genre::Primus,
-            109 => Genre::PornGroove,
-            110 => Genre::Satire,
-            111 => Genre::SlowJam,
-            112 => Genre::Club,
-            113 => Genre::Tango,
-            114 => Genre::Samba,
-            115 => Genre::Folklore,
-            116 => Genre::Ballad,
-            117 => Genre::PowerBallad,
-            118 => Genre::RhytmicSoul,
-            119 => Genre::Freestyle,
-            120 => Genre::Duet,
-            121 => Genre::PunkRock,
-            122 => Genre::DrumSolo,
-            123 => Genre::ACapela,
-            124 => Genre::EuroHouse,
-            125 => Genre::DanceHall,
-            _ => Genre::Unknown,
+            0 => Self::Blues,
+            1 => Self::ClassicRock,
+            2 => Self::Country,
+            3 => Self::Dance,
+            4 => Self::Disco,
+            5 => Self::Funk,
+            6 => Self::Grunge,
+            7 => Self::HipHop,
+            8 => Self::Jazz,
+            9 => Self::Metal,
+            10 => Self::NewAge,
+            11 => Self::Oldies,
+            12 => Self::Other,
+            13 => Self::Pop,
+            14 => Self::RAndB,
+            15 => Self::Rap,
+            16 => Self::Reggae,
+            17 => Self::Rock,
+            18 => Self::Techno,
+            19 => Self::Industrial,
+            20 => Self::Alternative,
+            21 => Self::Ska,
+            22 => Self::DeathMetal,
+            23 => Self::Pranks,
+            24 => Self::Soundtrack,
+            25 => Self::EuroTechno,
+            26 => Self::Ambient,
+            27 => Self::TripHop,
+            28 => Self::Vocal,
+            29 => Self::JazzFunk,
+            30 => Self::Fusion,
+            31 => Self::Trance,
+            32 => Self::Classical,
+            33 => Self::Instrumental,
+            34 => Self::Acid,
+            35 => Self::House,
+            36 => Self::Game,
+            37 => Self::SoundClip,
+            38 => Self::Gospel,
+            39 => Self::Noise,
+            40 => Self::AlternRock,
+            41 => Self::Bass,
+            42 => Self::Soul,
+            43 => Self::Punk,
+            44 => Self::Space,
+            45 => Self::Meditative,
+            46 => Self::InstrumentalPop,
+            47 => Self::InstrumentalRock,
+            48 => Self::Ethnic,
+            49 => Self::Gothic,
+            50 => Self::Darkwave,
+            51 => Self::TechnoIndustrial,
+            52 => Self::Electronic,
+            53 => Self::PopFolk,
+            54 => Self::Eurodance,
+            55 => Self::Dream,
+            56 => Self::SouthernRock,
+            57 => Self::Comedy,
+            58 => Self::Cult,
+            59 => Self::Gangsta,
+            60 => Self::Top40,
+            61 => Self::ChristianRap,
+            62 => Self::PopFunk,
+            63 => Self::Jungle,
+            64 => Self::NativeAmerican,
+            65 => Self::Cabaret,
+            66 => Self::NewWave,
+            67 => Self::Psychadelic,
+            68 => Self::Rave,
+            69 => Self::Showtunes,
+            70 => Self::Trailer,
+            71 => Self::LoFi,
+            72 => Self::Tribal,
+            73 => Self::AcidPunk,
+            74 => Self::AcidJazz,
+            75 => Self::Polka,
+            76 => Self::Retro,
+            77 => Self::Musical,
+            78 => Self::RockAndRoll,
+            79 => Self::HardRock,
+            80 => Self::Folk,
+            81 => Self::FolkRock,
+            82 => Self::NationalFolk,
+            83 => Self::Swing,
+            84 => Self::FastFusion,
+            85 => Self::Bebob,
+            86 => Self::Latin,
+            87 => Self::Revival,
+            88 => Self::Celtic,
+            89 => Self::Bluegrass,
+            90 => Self::Avantgarde,
+            91 => Self::GothicRock,
+            92 => Self::ProgressiveRock,
+            93 => Self::PsychedelicRock,
+            94 => Self::SymphonicRock,
+            95 => Self::SlowRock,
+            96 => Self::BigBand,
+            97 => Self::Chorus,
+            98 => Self::EasyListening,
+            99 => Self::Acoustic,
+            100 => Self::Humour,
+            101 => Self::Speech,
+            102 => Self::Chanson,
+            103 => Self::Opera,
+            104 => Self::ChamberMusic,
+            105 => Self::Sonata,
+            106 => Self::Symphony,
+            107 => Self::BootyBrass,
+            108 => Self::Primus,
+            109 => Self::PornGroove,
+            110 => Self::Satire,
+            111 => Self::SlowJam,
+            112 => Self::Club,
+            113 => Self::Tango,
+            114 => Self::Samba,
+            115 => Self::Folklore,
+            116 => Self::Ballad,
+            117 => Self::PowerBallad,
+            118 => Self::RhytmicSoul,
+            119 => Self::Freestyle,
+            120 => Self::Duet,
+            121 => Self::PunkRock,
+            122 => Self::DrumSolo,
+            123 => Self::ACapela,
+            124 => Self::EuroHouse,
+            125 => Self::DanceHall,
+            _ => Self::Unknown,
         }
     }
 }
@@ -491,7 +489,7 @@ impl From<u8> for Genre {
 impl fmt::Display for Genre {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Something(s) => write!(f, "{}", s),
+            Self::Something(s) => write!(f, "{s}"),
             _ => fmt::Debug::fmt(self, f),
         }
     }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -347,7 +347,8 @@ impl Default for Genre {
 
 impl<'a> From<&'a str> for Genre {
     fn from(c: &'a str) -> Self {
-        c.parse::<u8>().map_or_else(|_| Self::Something(c.to_owned()), Self::from)
+        c.parse::<u8>()
+            .map_or_else(|_| Self::Something(c.to_owned()), Self::from)
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -181,7 +181,11 @@ fn get_id3(i: &mut u32, buf: &[u8], meta: &mut MP3Metadata) -> Result<(), Error>
                                     .split(')')
                                     .collect::<Vec<&str>>()
                                     .into_iter()
-                                    .filter_map(|a| a.replace('(', "").parse::<u8>().map_or(None, |num| Some(Genre::from(num))))
+                                    .filter_map(|a| {
+                                        a.replace('(', "")
+                                            .parse::<u8>()
+                                            .map_or(None, |num| Some(Genre::from(num)))
+                                    })
                                     .collect::<Vec<Genre>>();
                                 if v.is_empty() {
                                     op.content_type.push(Genre::from(s.as_str()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use enums::{ChannelType, Copyright, Emphasis, Genre, Layer, Status, Version, CRC};
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct Frame {
     pub size: u32,
@@ -45,7 +46,7 @@ pub struct AudioTag {
 pub struct Url(pub String);
 
 // TODO: Add picture support
-/// id3.org/id3v2.3.0#Declared_ID3v2_frames#Text_information_frames_-_details
+/// `id3.org/id3v2.3.0#Declared_ID3v2_frames#Text_information_frames`_-_details
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct OptionalAudioTags {
     /// Corresponds to the nth frames `MP3Metadata.frame`.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,30 +9,30 @@ pub fn compute_duration(v: Version, l: Layer, sample_rate: u16) -> Option<Durati
         return None;
     }
     let mut big = match v {
-        Version::MPEG1 => SAMPLES_PER_FRAME[0][get_layer_value(l)] as u64 * 1_000_000_000,
+        Version::MPEG1 => u64::from(SAMPLES_PER_FRAME[0][get_layer_value(l)]) * 1_000_000_000,
         Version::MPEG2 | Version::MPEG2_5 => {
-            SAMPLES_PER_FRAME[1][get_layer_value(l)] as u64 * 1_000_000_000
+            u64::from(SAMPLES_PER_FRAME[1][get_layer_value(l)]) * 1_000_000_000
         }
         _ => return None,
     };
-    big /= sample_rate as u64;
+    big /= u64::from(sample_rate);
     Some(Duration::new(
         big / 1_000_000_000,
         (big % 1_000_000_000) as u32,
     ))
 }
 
-pub fn get_line(v: Version, l: Layer) -> usize {
+pub const fn get_line(v: Version, l: Layer) -> usize {
     match (v, l) {
         (Version::MPEG1, Layer::Layer1) => 0,
         (Version::MPEG1, Layer::Layer2) => 1,
         (Version::MPEG1, Layer::Layer3) => 2,
-        (Version::MPEG2, Layer::Layer1) | (Version::MPEG2_5, Layer::Layer1) => 3,
+        (Version::MPEG2 | Version::MPEG2_5, Layer::Layer1) => 3,
         _ => 4,
     }
 }
 
-pub fn get_layer_value(l: Layer) -> usize {
+pub const fn get_layer_value(l: Layer) -> usize {
     match l {
         Layer::Layer1 => 0,
         Layer::Layer2 => 1,
@@ -41,7 +41,8 @@ pub fn get_layer_value(l: Layer) -> usize {
     }
 }
 
-pub fn get_samp_line(v: Version) -> usize {
+#[allow(clippy::match_same_arms)]
+pub const fn get_samp_line(v: Version) -> usize {
     match v {
         Version::MPEG1 => 0,
         Version::MPEG2 => 1,
@@ -53,7 +54,7 @@ pub fn get_samp_line(v: Version) -> usize {
 pub fn create_latin1_str(buf: &[u8]) -> String {
     // interpret each byte as full codepoint. UTF-16 is big enough to
     // represent those, surrogate pairs can't be created that way
-    let utf16 = buf.iter().map(|c| *c as u16).collect::<Vec<u16>>();
+    let utf16 = buf.iter().map(|c| u16::from(*c)).collect::<Vec<u16>>();
     String::from_utf16_lossy(utf16.as_ref())
 }
 
@@ -65,14 +66,14 @@ pub fn create_utf16_str(buf: &[u8]) -> String {
             // UTF-16BE
             v.reserve(buf.len() / 2 - 1);
             for i in 1..buf.len() / 2 {
-                v.push((buf[2 * i] as u16) << 8 | (buf[2 * i + 1] as u16))
+                v.push(u16::from(buf[2 * i]) << 8 | u16::from(buf[2 * i + 1]));
             }
             return String::from_utf16_lossy(v.as_ref());
         } else if buf[0] == 0xff && buf[1] == 0xfe {
             // UTF-16LE
             v.reserve(buf.len() / 2 - 1);
             for i in 1..buf.len() / 2 {
-                v.push((buf[2 * i + 1] as u16) << 8 | (buf[2 * i] as u16))
+                v.push(u16::from(buf[2 * i + 1]) << 8 | u16::from(buf[2 * i]));
             }
             return String::from_utf16_lossy(v.as_ref());
         }
@@ -80,7 +81,7 @@ pub fn create_utf16_str(buf: &[u8]) -> String {
     // try as UTF-16LE
     v.reserve(buf.len() / 2);
     for i in 0..buf.len() / 2 {
-        v.push((buf[2 * i + 1] as u16) << 8 | (buf[2 * i] as u16))
+        v.push(u16::from(buf[2 * i + 1]) << 8 | u16::from(buf[2 * i]));
     }
     return String::from_utf16_lossy(v.as_ref());
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -25,18 +25,18 @@ fn basic() {
                         frame.duration
                     );
                 } else {
-                    if meta.frames[i].sampling_freq as u32 != frame.sample_rate {
+                    if u32::from(meta.frames[i].sampling_freq) != frame.sample_rate {
                         println!(
                             "[{}] [SAMPLE_RATE] {} != {}",
                             i, meta.frames[i].sampling_freq, frame.sample_rate
                         );
                         panic!();
                     }
-                    if meta.frames[i].bitrate as u32 * 1000 != frame.bit_rate {
+                    if u32::from(meta.frames[i].bitrate) * 1000 != frame.bit_rate {
                         println!(
                             "[{}] [BIT_RATE] {} != {}",
                             i,
-                            meta.frames[i].bitrate as u32 * 1000,
+                            u32::from(meta.frames[i].bitrate) * 1000,
                             frame.bit_rate
                         );
                         panic!();
@@ -68,21 +68,21 @@ fn basic() {
         assert_eq!(frame.crc, mp3_metadata::CRC::Added, "crc");
         assert_eq!(frame.bitrate, 128, "bitrate");
         assert_eq!(frame.sampling_freq, 44100, "sampling freq");
-        assert_eq!(frame.padding, false, "padding");
-        assert_eq!(frame.private_bit, false, "private bit");
+        assert!(!frame.padding, "padding");
+        assert!(!frame.private_bit, "private bit");
         assert_eq!(
             frame.chan_type,
             mp3_metadata::ChannelType::SingleChannel,
             "channel type"
         );
-        assert_eq!(frame.intensity_stereo, false, "intensity stereo");
-        assert_eq!(frame.ms_stereo, false, "ms stereo");
+        assert!(!frame.intensity_stereo, "intensity stereo");
+        assert!(!frame.ms_stereo, "ms stereo");
         assert_eq!(frame.copyright, mp3_metadata::Copyright::None, "copyright");
         assert_eq!(frame.status, mp3_metadata::Status::Copy, "status");
         assert_eq!(frame.emphasis, mp3_metadata::Emphasis::None, "emphasis");
     }
     assert_eq!(meta.frames.len(), 475, "number of frames");
-    assert_eq!(meta.duration, Duration::new(12, 408162800), "duration");
+    assert_eq!(meta.duration, Duration::new(12, 408_162_800), "duration");
     assert_eq!(
         meta.tag,
         Some(mp3_metadata::AudioTag {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -9,7 +9,7 @@ pub fn get_file<P: AsRef<Path>>(p: P) {
     if p.exists() {
         return;
     }
-    let mut resp = reqwest::blocking::get(&format!(
+    let mut resp = reqwest::blocking::get(format!(
         "https://guillaume-gomez.fr/rust-test/{}",
         p.file_name()
             .expect("file_name() failed")

--- a/tests/id3v2.rs
+++ b/tests/id3v2.rs
@@ -13,11 +13,11 @@ fn id3v2() {
     assert_eq!(meta.optional_info[0].bpm, None);
     assert_eq!(
         meta.optional_info[0].composers,
-        vec!("not Mozart".to_owned(), "not Beethoven".to_owned())
+        vec!["not Mozart".to_owned(), "not Beethoven".to_owned()]
     );
     assert_eq!(
         meta.optional_info[0].content_type,
-        vec!(mp3_metadata::Genre::InstrumentalPop)
+        vec![mp3_metadata::Genre::InstrumentalPop]
     );
     assert_eq!(
         meta.optional_info[0].copyright,
@@ -40,7 +40,7 @@ fn id3v2() {
     );
     assert_eq!(
         meta.optional_info[0].performers,
-        vec!("Someone".to_owned(), "Someone else".to_owned())
+        vec!["Someone".to_owned(), "Someone else".to_owned()]
     );
     assert_eq!(
         meta.optional_info[0].band,
@@ -53,7 +53,7 @@ fn id3v2() {
         Some(mp3_metadata::AudioTag {
             title: "This is a wonderful title isn'".to_owned(),
             artist: "Someone/Someone else          ".to_owned(),
-            album: "".to_owned(),
+            album: String::new(),
             year: 2015,
             comment: "Some random comment because ".to_owned(),
             genre: mp3_metadata::Genre::Other,

--- a/tests/invalid_time.rs
+++ b/tests/invalid_time.rs
@@ -28,17 +28,17 @@ fn invalid_time() {
                     i += 1;
                     continue;
                 }
-                if meta.frames[i].sampling_freq as u32 != frame.sample_rate {
+                if u32::from(meta.frames[i].sampling_freq) != frame.sample_rate {
                     println!(
                         "[{}] [SAMPLE_RATE] {} != {}",
                         i, meta.frames[i].sampling_freq, frame.sample_rate
                     );
                 }
-                if meta.frames[i].bitrate as u32 * 1000 != frame.bit_rate {
+                if u32::from(meta.frames[i].bitrate) * 1000 != frame.bit_rate {
                     println!(
                         "[{}] [BIT_RATE] {} != {}",
                         i,
-                        meta.frames[i].bitrate as u32 * 1000,
+                        u32::from(meta.frames[i].bitrate) * 1000,
                         frame.bit_rate
                     );
                 }

--- a/tests/truncate.rs
+++ b/tests/truncate.rs
@@ -12,15 +12,15 @@ fn truncate() {
         assert_eq!(frame.crc, mp3_metadata::CRC::Added);
         assert_eq!(frame.bitrate, 128);
         assert_eq!(frame.sampling_freq, 44100);
-        assert_eq!(frame.padding, false);
-        assert_eq!(frame.private_bit, false);
+        assert!(!frame.padding);
+        assert!(!frame.private_bit);
         assert_eq!(frame.chan_type, mp3_metadata::ChannelType::SingleChannel);
-        assert_eq!(frame.intensity_stereo, false);
-        assert_eq!(frame.ms_stereo, false);
+        assert!(!frame.intensity_stereo);
+        assert!(!frame.ms_stereo);
         assert_eq!(frame.copyright, mp3_metadata::Copyright::None);
         assert_eq!(frame.status, mp3_metadata::Status::Copy);
         assert_eq!(frame.emphasis, mp3_metadata::Emphasis::None);
     }
-    assert_eq!(meta.duration, Duration::new(12, 120815872));
+    assert_eq!(meta.duration, Duration::new(12, 120_815_872));
     assert_eq!(meta.tag, None);
 }


### PR DESCRIPTION
Ran `cargo clippy -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used` and cleaned up most of what it found.

This was a 30-minute cleanup. The remaining stuff takes little digging into the code and should probably be done by the original author.