### PR TITLE
Strip trailing NUL bytes from strings

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -85,7 +85,16 @@ pub fn create_utf16_str(buf: &[u8]) -> String {
     return String::from_utf16_lossy(v.as_ref());
 }
 
-pub fn create_utf8_str(buf: &[u8]) -> String {
+pub fn create_utf8_str(mut buf: &[u8]) -> String {
+    // Remove trailing NUL bytes from the input
+    while let [rest @ .., last] = buf {
+        if *last == 0 {
+            buf = rest;
+        } else {
+            break;
+        }
+    }
+
     // String::from_utf8_lossy(buf).into_owned()
     String::from_utf8(buf.to_owned()).unwrap_or_default()
 }


### PR DESCRIPTION
I have some mp3 files that show up with metadata like this:

```
title: Some("Woken Furies\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
artist: Some("GUNSHIP\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"),
album: Some("Dark All Day [Explicit]\0\0\0\0\0\0\0"),
```

this commit strips trailing newlines from the byte string before attempting to convert it to UTF8, which results in the desired outcome:

```
title: Some("Woken Furies"),
artist: Some("GUNSHIP"),
album: Some("Dark All Day [Explicit]")
```

Note that `cargo test` fails in master currently with a segfault; that is a pre-existing condition and is not related to this change, and is discussed in https://github.com/GuillaumeGomez/mp3-metadata/pull/34